### PR TITLE
Add canonical links for SEO

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,7 +41,7 @@ google_analytics: UA-71317831-1
 
 # Your website URL (e.g. http://barryclark.github.io or http://www.barryclark.co)
 # Used for Sitemap.xml and your RSS feed
-url:
+url: "https://ard.ninja"
 
 # If you're hosting your site at a Project repository on GitHub pages
 # (http://yourusername.github.io/repository-name)

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -9,6 +9,13 @@
     <meta name="description" content="{{ site.description }}">
     <meta property="og:description" content="{{ site.description }}" />
     {% endif %}
+    <link rel="canonical" href="{{ page.url | absolute_url }}" />
+    <meta property="og:url" content="{{ page.url | absolute_url }}" />
+    {% if page.layout == 'post' %}
+    <meta property="og:type" content="article" />
+    {% else %}
+    <meta property="og:type" content="website" />
+    {% endif %}
     <meta name="author" content="{{ site.name }}" />
     {% if page.title %}
     <meta property="og:title" content="{{ page.title }}" />


### PR DESCRIPTION
## Summary
- set `url` for sitemap and canonical meta
- add canonical, OG URL, and OG type tags

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68472907e4b08328945f9fdde22f3f09