### PR TITLE
Fix typo in landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@ layout: default
     for a high growth startup.
   </p>
   <p>
-    As en engineer I'm deeply experienced in scaling and parallelizing
+    As an engineer I'm deeply experienced in scaling and parallelizing
     typescript based lambdas in AWS, designing and building out backend systems,
     crafting database schemas, and generally an all around experienced
     programmer.


### PR DESCRIPTION
## Summary
- fix "As en engineer" typo on the home page

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68472a89d8bc8328bd4074b467a5327d