### PR TITLE
Fix LeadTruffle link

### DIFF
--- a/_posts/2025-03-08-making-the-product-sing.markdown
+++ b/_posts/2025-03-08-making-the-product-sing.markdown
@@ -18,7 +18,7 @@ I listen to what customers say: mention once it's on my radar. Two customers men
 
 I have my entire product's feature set written out in English with a mapping of every page and link and I iterate over it with o1 and r1.
 
-Bryan and I watch almost every conversation that comes in [LeadTruffle - our new AI first lead handling too for home services](https://leadtruffle.com) and we probably will continue to do so until there is so much volume we can't anymore.
+Bryan and I watch almost every conversation that comes in [LeadTruffle - our new AI first lead handling too for home services](https://www.leadtruffle.co) and we probably will continue to do so until there is so much volume we can't anymore.
 
 ## Just do the extra effort.
 


### PR DESCRIPTION
## Summary
- update LeadTruffle URL in `making-the-product-sing` post

## Testing
- `grep -R "leadtruffle.com" -n`


------
https://chatgpt.com/codex/tasks/task_e_6847431f59a48328826eb3dc687be956