### PR TITLE
Add google site verification tag

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -21,3 +21,4 @@
     <meta property="og:title" content="{{ page.title }}" />
     <meta property="twitter:title" content="{{ page.title }}" />
     {% endif %}
+    <meta name="google-site-verification" content="JHkT1AugGeQW1_Vgmg4t1niZzvcJSz-8zJ6jlkSLsL4" />


### PR DESCRIPTION
## Summary
- include Google verification meta tag in the default head

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851543d37a08328ab28c699e8e40dd3