### PR TITLE
Fix typos in Donnie Pump blog post

### DIFF
--- a/_posts/2020-06-28-donnie-pump-covid-press-conference-trading-system copy.markdown
+++ b/_posts/2020-06-28-donnie-pump-covid-press-conference-trading-system copy.markdown
@@ -5,7 +5,7 @@ date: 2020-06-28
 layout: post
 slug: 2020-06-28-donnie-pump-covid-press-conference-trading-system
 title: "\"Donnie Pump\" a Presidential Press Conference Trading System."
-description: For a while it seemed like everyday in March of 2020 there was a whitehouse press conference. This is an experiment building a system to help trade against this. 
+description: For a while it seemed like everyday in March of 2020 there was a White House press conference. This is an experiment building a system to help trade against this.
 ---
 
 ![Screencap of the March 13th 2020 Rose Garden Press Conference](/images/blog/press-conf-screenshot-1.png){: .center-image }
@@ -13,7 +13,7 @@ _Screencap of the March 13th 2020 Rose Garden Press Conference._{: .center-image
 
 ## The Inspiration
 
-The photo above is a screenshot of the CNBC stream of the infamous [Rose Garden Coronavirus press conference](https://www.youtube.com/watch?v=mB6mzESzUf0) where the Trump administration trotted out a bunch of fortune 500 CEOs on March 13 2020. This was a few weeks into the COVID-19 pandemic and after the market had started to sell off earnest. The market had hit a 7% down trading halt the day before, so they were trying to instill confidence.
+The photo above is a screenshot of the CNBC stream of the infamous [Rose Garden Coronavirus press conference](https://www.youtube.com/watch?v=mB6mzESzUf0) where the Trump administration trotted out a bunch of Fortune 500 CEOs on March 13 2020. This was a few weeks into the COVID-19 pandemic and after the market had started to sell off in earnest. The market had hit a 7% down trading halt the day before, so they were trying to instill confidence.
 
 I was watching this live, dumbstruck as they brought out one CEO after another of a major publicly traded corporation and I watched the charts as stocks for these individual companies spiked almost immediately after each CEO spoke.
 
@@ -21,18 +21,18 @@ This was the inspiration for building a tool to help trade these daily Coronavir
 
 It seemed like just about every press conference the president would mention a specific publicly traded company and then seconds later the stock would start to move up. Typically, I noticed the stock might move up anywhere from 3% to 10% over the course of about 5 or 10 minutes and then either even out or revert back to where it was.
 
-To me, this seemed like an easy thing to profit from programatically. My friend [Marcus Wood](https://www.marcuswood.io/) agreed.
+To me, this seemed like an easy thing to profit from programmatically. My friend [Marcus Wood](https://www.marcuswood.io/) agreed.
 
 ## The Idea
 
-I went to work with Marcus on the idea that weekend. At first we were thinking we could just do this without human interaction [as people do with Trump's tweets](https://medium.com/@maxbraun/this-machine-turns-trump-tweets-into-planned-parenthood-donations-4ece8301e722) but after toying with that idea we realized how complex it actually it is.
+I went to work with Marcus on the idea that weekend. At first we were thinking we could just do this without human interaction [as people do with Trump's tweets](https://medium.com/@maxbraun/this-machine-turns-trump-tweets-into-planned-parenthood-donations-4ece8301e722) but after toying with that idea we realized how complex it actually is.
 
 The process goes somewhat like this:
 
 1. You need to transcribe the speech from the press conference to text
-2. You need to pick out individual public traded companies that are mentioned (e.g. "McDonalds")
+2. You need to pick out individual publicly traded companies that are mentioned (e.g. "McDonalds")
 3. You need to convert these company names to ticker symbols ("McDonalds" --> "MCD")
-4. Understand if this is good, bad, or old news (wont move the market).
+4. Understand if this is good, bad, or old news (won't move the market).
 5. Make an appropriate trade
 6. Exit the trade at an appropriate time
 
@@ -54,13 +54,13 @@ I had been wanting to try out the [Alpaca trading API](https://alpaca.markets/do
 
 Marcus went to work on the UI and we built out what ended up being the basis of a trading platform we could implement multiple ideas in ([which he wrote a little bit more about here](https://www.marcuswood.io/products/suri)).
 
-The backend is written in Node.js, where in addition to connecting to Alpaca to trade and get market data I wrote the component which would take transcribed speech from the client and try to match this to a list of known publicly traded companies. This was harder than it seemed. There are a lot of common words like "corporation", "technologies", "partners" and even "health" which came up frequently in press conference but were also in the names of many companies.
+The backend is written in Node.js, where in addition to connecting to Alpaca to trade and get market data I wrote the component which would take transcribed speech from the client and try to match this to a list of known publicly traded companies. This was harder than it seemed. There are a lot of common words like "corporation", "technologies", "partners" and even "health" which came up frequently in press conferences but were also in the names of many companies.
 
 There are thousands of companies listed on NYSE and NASDAQ so what we ended up doing is building a curated list of names we thought were worth trading against. If I had a lot of time and a team of people I could do this a lot better against every listed company and would solve the problem differently.
 
-Developing the rest of the platform was interesting - I hadn't worked on many things where a realtime UI was so important. Sure, server side code has to be fast. But its a little different when the client and server need to be in sync so tightly.
+Developing the rest of the platform was interesting - I hadn't worked on many things where a real-time UI was so important. Sure, server side code has to be fast. But it's a little different when the client and server need to be in sync so tightly.
 
-What we ended up doing was shoving basically everything through a websocket connection. No restful architecture or GraphQL for this one! Everything was a websocket event. Marcus moved the client to use [MobX](https://mobx.js.org/README.html) which was designed for this sort of thing. The UI is written in React.
+What we ended up doing was shoving basically everything through a WebSocket connection. No RESTful architecture or GraphQL for this one! Everything was a WebSocket event. Marcus moved the client to use [MobX](https://mobx.js.org/README.html) which was designed for this sort of thing. The UI is written in React.
 
 One other thing to note: the speech transcription was surprisingly easy because modern browsers actually have speech to text built in. We used the [Speech Recognition API and it worked great](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition).
 
@@ -70,13 +70,13 @@ I made a little GIF of a clip of the Rose Garden press conference when the presi
 
 ![gif of the rose garden press conference demo](/images/blog/rose-garden-presser-demo-1.gif)
 
-[Here is a link to the fullsize version](/images/blog/rose-garden-presser-demo-1.gif)
+[Here is a link to the full-size version](/images/blog/rose-garden-presser-demo-1.gif)
 
 ## Placing Orders
 
 Alpaca has some cool order types. One of which [is a "Bracket" order](https://alpaca.markets/docs/api-documentation/api-v2/orders/) which allows you do multiple things at once. For this project I wanted to enter a market buy when I heard the name e.g. "McDonalds" but then I also wanted to put in 2 limit orders based on this market order. I wanted to put in a stop loss to sell out of the position in case it moved against me, and I wanted to put in a limit order to sell at a higher price to take profits if I was right.
 
-They allow you do just this with a single API Call. The payload looks like this:
+They allow you do just this with a single API call. The payload looks like this:
 
 {% highlight javascript %}
 {
@@ -105,7 +105,7 @@ Another thing I did was make sure we had a "Liquidate Positions" button on the U
 
 I've written a few automated systems based on trend following and mean reversion patterns before, but I've never built anything to make myself a platform to trade as a human operator directly. It presented some unique things to think about, and I keep thinking of new ideas I want to implement.
 
-I really hope that Alpaca starts to support options trading a futures markets soon because I have a couple of ideas around doing psuedo-arbitrage between commodities and equities related to those underlying commodities in a programatic manner. They have a really great API that is easy to work with but I'd like to see a lot more features from it. I'm still using Quant Connect for backtesting new ideas at this point.
+I really hope that Alpaca starts to support options trading and futures markets soon because I have a couple of ideas around doing pseudo-arbitrage between commodities and equities related to those underlying commodities in a programmatic manner. They have a really great API that is easy to work with but I'd like to see a lot more features from it. I'm still using Quant Connect for backtesting new ideas at this point.
 
 Till next time!
 


### PR DESCRIPTION
## Summary
- correct typos in the Donnie Pump trading system post

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685c6b1dfe08832885617779360ef27b