### PR TITLE
Fix typos in multiple posts

### DIFF
--- a/_posts/2016-09-19-finding-freelance-development-work.markdown
+++ b/_posts/2016-09-19-finding-freelance-development-work.markdown
@@ -54,7 +54,7 @@ The platforms you can do this with don't matter: Linkedin, Twitter, Facebook, in
 
 ### Do Great Work, Aim For Referrals
 
-If small-scale web development is becoming commoditized to the point where hosting companies, self-serve website builders, and $10 an hour overseas help is is now literally ubiquitous, how can you make any money?
+If small-scale web development is becoming commoditized to the point where hosting companies, self-serve website builders, and $10 an hour overseas help is now literally ubiquitous, how can you make any money?
 
 You must do what the rest can't: offer good, smart service that solves problems well and completely, preferably on the first attempt. Wix.com is not meant to do what the customer wants intelligently all by itself. It is a platform that lets you quickly throw stuff up on the web if you already know what you are doing. Overseas developers will never be able to communicate as effectively as somebody that lives in the same town and can meet face to face or quickly jump on the phone.
 

--- a/_posts/2020-12-04-testing-a-simple-buy-the-dip-alpaca-system-4-months-in.markdown
+++ b/_posts/2020-12-04-testing-a-simple-buy-the-dip-alpaca-system-4-months-in.markdown
@@ -68,7 +68,7 @@ Yeah, I think it could but again this was more about just trying to get somethin
 
 I do think something like this would be very useful for accumulating thinly traded small cap or OTC stocks over a long period of time. 
 
-One thing I was thinking would be great to have something like this for is accumulating the various Fannie Mae / Freddie Mac preferred shares. There are a ton of ticker symbols for these on the pink sheets and they are thinly traded and sometimes make wild and irrational moves. Sometimes I think people will just randomly liquidate positions in these but really the only thing that matters for these shares the the progress of the lawsuits and [the recapitalization plan](https://www.wsj.com/articles/fannie-freddie-tap-wall-street-banks-to-advise-on-recapitalization-11592252631).
+One thing I was thinking would be great to have something like this for is accumulating the various Fannie Mae / Freddie Mac preferred shares. There are a ton of ticker symbols for these on the pink sheets and they are thinly traded and sometimes make wild and irrational moves. Sometimes I think people will just randomly liquidate positions in these but really the only thing that matters for these shares is the progress of the lawsuits and [the recapitalization plan](https://www.wsj.com/articles/fannie-freddie-tap-wall-street-banks-to-advise-on-recapitalization-11592252631).
 
 
 

--- a/_posts/2022-08-14-bureaucracy-navigation-as-a-service.markdown
+++ b/_posts/2022-08-14-bureaucracy-navigation-as-a-service.markdown
@@ -3,7 +3,7 @@ author: Aaron Decker
 comments: true
 date: 2022-08-14
 layout: post
-slug: 2022-08-14-bureaucracy-navigation-as-a-services
+slug: 2022-08-14-bureaucracy-navigation-as-a-service
 title: Bureaucracy navigation as a service startup ideas
 description: Trying to define whole categories of software related to automating bureaucracy and why they are good businesses.
 ---
@@ -32,7 +32,7 @@ As an aside, one of the funniest things to me about Europe is that instead of al
 
 ## Automating bureaucracy
 
-I have been thinking a lot lately about what it means to automate bureaucracy. It's clear that the longer governments exist and the more aggressively they intervene in the business world (such as what we've seen starting in 2020) the more this becomes a problem and ultimately it posses a risk to human civilizational progress.
+I have been thinking a lot lately about what it means to automate bureaucracy. It's clear that the longer governments exist and the more aggressively they intervene in the business world (such as what we've seen starting in 2020) the more this becomes a problem and ultimately it poses a risk to human civilizational progress.
 
 My personal theory is that the harder that governments make things for business owners on the compliance front, the more we can automate compliance. Eventually this becomes a simple cost of doing business that can be driven lower and lower due to automation.
 
@@ -60,7 +60,7 @@ I have heard that the two most complex parts of US law are the tax code and immi
 
 ## The advantages and disadvantages of these companies
 
-The advantage of software company that automates bureaucracy navigation is that it's almost like being a government employee. The work will exist as long as the government structure exists, and usually these exist a pretty long time.
+The advantage of a software company that automates bureaucracy navigation is that it's almost like being a government employee. The work will exist as long as the government structure exists, and usually these exist a pretty long time.
 
 The disadvantage of these types of companies is that you have to be careful of addressable market size. Can you automate small business permit compliance for sandwich shops in New York City? Yes, probably and will it be worth it? Well maybe... But how about sandwich shops in Cincinnati, OH? Almost certainly not. The market is just too small.
 

--- a/_posts/2022-12-11-organization-heirarchy-as-hidden-markov-model-for-sales.markdown
+++ b/_posts/2022-12-11-organization-heirarchy-as-hidden-markov-model-for-sales.markdown
@@ -20,7 +20,7 @@ So to summarize: you have system with a process you don't understand fully but y
 
 I was thinking recently how this is a good way to think about the sales process with a large organization. Say there is a large company (take Coca Cola as an example) and you want to sell them your software for $50,000 a month.
 
-You know the possible end states - **Yes**, **No**, etc. But you don't initially know the decision makers who are capable of agreeing to this $10,000 a month sale, and you dont know all the boxes you need to check the the different departments to get to "Yes" state.
+You know the possible end states - **Yes**, **No**, etc. But you don't initially know the decision makers who are capable of agreeing to this $10,000 a month sale, and you don't know all the boxes you need to check with the different departments to get to the "Yes" state.
 
 Job titles vary greatly from one org to the next - e.g. maybe the CEO is actually very checked out of the day to day operations and talking to them won't get you anywhere for your sale. Perhaps the VP of marketing is the person to talk to!
 

--- a/_posts/2023-03-18-attention-in-the-western-hemisphere-is-a-gaussian-beam.markdown
+++ b/_posts/2023-03-18-attention-in-the-western-hemisphere-is-a-gaussian-beam.markdown
@@ -34,7 +34,7 @@ I was also thinking about how this further applies to organizations. They have a
 
 I think the same logic applies to government agencies. Their focus can be brought to bear on one big thing but in doing so it removes the focal point from other duties.
 
-You may have noticed there are a lot of for-profit organizations lately that vocally are changing their mission statements to things **other** than turning a profit. My point here is I think you should believe them at face value - if you say your top priority is something **other** than turning a profit and focusing on you business, you probably wont be turning a profit much longer.
+You may have noticed there are a lot of for-profit organizations lately that vocally are changing their mission statements to things **other** than turning a profit. My point here is I think you should believe them at face value - if you say your top priority is something **other** than turning a profit and focusing on your business, you probably won't be turning a profit much longer.
 
 ## Follow the focal point
 

--- a/_posts/2023-06-08-semantic-search-and-unsupervised-learning-powering-saymore-ai.markdown
+++ b/_posts/2023-06-08-semantic-search-and-unsupervised-learning-powering-saymore-ai.markdown
@@ -230,12 +230,12 @@ This gives you something pretty close to a "trending" result.
 
 The iffy parts are the following: reducing dimensionality loses a lot of data, and picking the number of clusters for the data is very data dependent.
 
-Fortunatly, I did some experiments with different clustering algorithms and I found that some density based algorithsm like [OPTICS](https://en.wikipedia.org/wiki/OPTICS_algorithm) yielded some better results.
+Fortunately, I did some experiments with different clustering algorithms and I found that some density based algorithms like [OPTICS](https://en.wikipedia.org/wiki/OPTICS_algorithm) yielded some better results.
 
 Experimentally, they seem to be superior for this task because of the following reasons:
 
-- the algorithm chooses the number clusters based on your tuning of the sensitivity
-- they seem to tolerate high-dimensional data better so you dont need to do PCA.
+- the algorithm chooses the number of clusters based on your tuning of the sensitivity
+- they seem to tolerate high-dimensional data better so you don't need to do PCA.
 
 Doing PCA on high dimensional semantic vectors means you are tossing the majority of the data out, and given that semantic vectors store many complex relationships in the high dimensional space, I don't know how well this will work in production (although the K-Means version did reasonably well in my limited testing).
 

--- a/_posts/2024-07-31-creating-potently-agentic-individually-aligned-models.markdown
+++ b/_posts/2024-07-31-creating-potently-agentic-individually-aligned-models.markdown
@@ -128,7 +128,7 @@ At that point, who is really in control? Surely the AI is? And isn’t this bett
 
 Avi Schiffmann's friend.com is in pre-order now and he released [this video](https://x.com/AviSchiffmann/status/1818284595902922884) just a few days after I wrote this post. 
 
-I think it's worth mentioning the launch of this product now because it's probably the closest thing we have now that is attempting the list I mentioned above that will get you to this perfectly agentic model. The device is taking in real-time sensory data from the user's POV & it's storing historical information. I will be interested to see what else it does, but what I have outlined above is where I believe these devices can go. Everyone else is not thinking far enough ahead and just seems to view them as gimicky little devices (which they kind-of are right now).
+I think it's worth mentioning the launch of this product now because it's probably the closest thing we have now that is attempting the list I mentioned above that will get you to this perfectly agentic model. The device is taking in real-time sensory data from the user's POV & it's storing historical information. I will be interested to see what else it does, but what I have outlined above is where I believe these devices can go. Everyone else is not thinking far enough ahead and just seems to view them as gimmicky little devices (which they kind-of are right now).
 
 ![friend.com screenshot](/images/blog/friend-com.png){: .center-image }
 <br />

--- a/_posts/2024-11-18-information-gradients-lead-to-technocapital-sinks.markdown
+++ b/_posts/2024-11-18-information-gradients-lead-to-technocapital-sinks.markdown
@@ -10,7 +10,7 @@ description: Find new technologies before they are discovered by the market.
 
 ![technocapital](/images/blog/dalle/technocapital-1.webp){: .center-image }
 
-You should go around looking for information gradients where a deep well of technoligical information exists that the rest of the market doesn't know about yet.
+You should go around looking for information gradients where a deep well of technological information exists that the rest of the market doesn't know about yet.
 
 It goes hand in hand with building an accurate model of reality. If you learned about transformer architecture when GPT3 first came out and the scaling predictions it should have been a small leap to understand chip makers would benefit. It wasn't hard to see the impact being able to zero-shot classify and manipulate unstructured data would have on the market. 
 
@@ -23,9 +23,9 @@ The accumulation of technocapital is like particles in nature seeking an equilib
 ![technocapital](/images/blog/sigmoid.png){: .center-image }
 
 
-The depth of the technocapital sink is proportional to the market exploitabily of the technology. Rich veins of technology will deeply attract capital, which will cause further advances in technology if they are profitable, but the market exploitability is very important for the cycle to accumulate more capital and not just die out or flounder. 
+The depth of the technocapital sink is proportional to the market exploitability of the technology. Rich veins of technology will deeply attract capital, which will cause further advances in technology if they are profitable, but the market exploitability is very important for the cycle to accumulate more capital and not just die out or flounder.
 
-- The internet: incredibly market exploitable, the best we have every seen. 
+- The internet: incredibly market exploitable, the best we have ever seen.
 - Cellphones: deeply market exploitable
 - AI chips: moderately market exploitable (so far)
 - 3D printing: only mildly market exploitable


### PR DESCRIPTION
## Summary
- fix typos in organization sales post
- correct spelling errors in SayMore AI article
- fix wording in Gaussian beam blog
- update bureaucracy navigation article
- correct text in buy-the-dip Alpaca write-up
- clean up freelance work tips
- clarify phrasing in technocapital post
- fix minor typo in aligned models post

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685cd3a64f588328a2953c9f8d30425f